### PR TITLE
chore: set minSdkVersion & compileSdkVersion to follow Flutter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,19 +29,19 @@ android {
     compileSdkVersion 35
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 26
+        minSdkVersion flutter.minSdkVersion
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace  'com.cuboid.open_mail'
-    compileSdkVersion 35
+    compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -397,7 +397,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.1"
+    version: "1.1.0"
   package_config:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   platform: ^3.1.0
-  url_launcher: ^6.3.1
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Change the android settings for:
1. minSdkVersion to flutter.minSdkVersion
2. compileSdkVersion to flutter.compileSdkVersion
3. Java compability to Version 11

Up the package url_launcher to ^6.3.2