### PR TITLE
Fix falsy documentation

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -86,7 +86,7 @@ class MyApp extends StatelessWidget {
               child: const Text("Open Specific One Mail App"),
               onPressed: () async {
                 try {
-                  // Open the first available mail app directly if only one is installed
+                  // Get all available mail apps
                   var apps = await OpenMail.getMailApps();
 
                   // If no mail apps are installed

--- a/lib/src/src.dart
+++ b/lib/src/src.dart
@@ -205,8 +205,7 @@ class OpenMail {
   ///
   /// Android: Will open mail app or show native picker if multiple.
   ///
-  /// iOS: Will open mail app if single installed mail app is found. If multiple
-  /// are found will return a [OpenMailAppResult] that contains list of
+  /// iOS: Will open the first mail app found. Returns a [OpenMailAppResult] that contains list of
   /// [MailApp]s. This can be used along with [MailAppPickerDialog] to allow
   /// the user to pick the mail app they want to open.
   ///


### PR DESCRIPTION
Hello,

`openMailApp` states that on iOS if several apps are available it will not open one and just return the result. 
In reality it does open it has the name suggest.

